### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/John0n1/ON1Builder/security/code-scanning/45](https://github.com/John0n1/ON1Builder/security/code-scanning/45)

In general, fix this by explicitly specifying a minimal `permissions` block for the workflow or individual jobs so the `GITHUB_TOKEN` does not inherit overly broad repository defaults. For a simple CI job that only checks out code and runs local tools, `contents: read` is sufficient.

For this specific workflow, the simplest and safest fix without changing functionality is to add a root-level `permissions` block directly under `name: CI`, setting `contents: read`. This will apply to all jobs (currently only `lint`) that do not override permissions. No additional imports or methods are required because this is a YAML configuration change only.

Concretely: edit `.github/workflows/ci.yml` and insert:

```yaml
permissions:
  contents: read
```

between the existing `name: CI` line and the `on:` block. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
